### PR TITLE
Add mechanisms to protect the APIToken resource

### DIFF
--- a/pkg/cli/integrationcli/run.go
+++ b/pkg/cli/integrationcli/run.go
@@ -46,7 +46,7 @@ func RunCmd() *cobra.Command {
 				return err
 			}
 
-			err = zone.ReconcileSettings(ctx, *instance, cf)
+			err = zone.ReconcileSettings(ctx, instance, cf)
 			if err != nil {
 				return err
 			}

--- a/pkg/cli/kubeflarecli/manager.go
+++ b/pkg/cli/kubeflarecli/manager.go
@@ -78,7 +78,7 @@ func ManagerCmd() *cobra.Command {
 				}
 			}
 
-			if err := zonecontroller.Add(mgr); err != nil {
+			if err := zonecontroller.Add(mgr, protectAPIToken); err != nil {
 				logger.Error(err)
 				os.Exit(1)
 			}

--- a/pkg/cli/kubeflarecli/manager.go
+++ b/pkg/cli/kubeflarecli/manager.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/replicatedhq/kubeflare/pkg/apis"
 	accessapplicationcontroller "github.com/replicatedhq/kubeflare/pkg/controller/accessapplication"
+	apitokencontroller "github.com/replicatedhq/kubeflare/pkg/controller/apitoken"
 	dnsrecordcontroller "github.com/replicatedhq/kubeflare/pkg/controller/dnsrecord"
 	pagerulecontroller "github.com/replicatedhq/kubeflare/pkg/controller/pagerule"
 	wafrulecontroller "github.com/replicatedhq/kubeflare/pkg/controller/webapplicationfirewallrule"
@@ -67,6 +68,16 @@ func ManagerCmd() *cobra.Command {
 				os.Exit(1)
 			}
 
+			protectAPIToken := v.GetBool("protect-apitoken")
+			if protectAPIToken {
+				err = apitokencontroller.Add(mgr)
+
+				if err != nil {
+					logger.Error(err)
+					os.Exit(1)
+				}
+			}
+
 			if err := zonecontroller.Add(mgr); err != nil {
 				logger.Error(err)
 				os.Exit(1)
@@ -115,6 +126,7 @@ func ManagerCmd() *cobra.Command {
 	cmd.Flags().String("metrics-addr", ":8088", "The address the metric endpoint binds to.")
 	cmd.Flags().Bool("leader-elect", true, "Enable leader election for controller manager. "+
 		"Enabling this will ensure there is only one active controller manager.")
+	cmd.Flags().Bool("protect-apitoken", false, "Protect APIToken from deletion if it is referenced by other managed resources.")
 
 	return cmd
 }

--- a/pkg/controller/apitoken/apitoken_controller.go
+++ b/pkg/controller/apitoken/apitoken_controller.go
@@ -1,0 +1,242 @@
+/*
+Copyright 2019 Replicated, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apitoken
+
+import (
+	"context"
+	"github.com/replicatedhq/kubeflare/pkg/internal"
+	"go.uber.org/zap"
+	v1 "k8s.io/api/core/v1"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"time"
+
+	"github.com/pkg/errors"
+	crdsv1alpha1 "github.com/replicatedhq/kubeflare/pkg/apis/crds/v1alpha1"
+	"github.com/replicatedhq/kubeflare/pkg/controller/shared"
+	"github.com/replicatedhq/kubeflare/pkg/logger"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubeinformers "k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+// Add creates a new APIToken Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
+// and Start it when the Manager is Started.
+func Add(mgr manager.Manager) error {
+	if err := add(mgr, newReconciler(mgr)); err != nil {
+		return err
+	}
+
+	return addSecret(mgr, newSecretReconciler(mgr))
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+	return &ReconcileAPIToken{
+		Client: mgr.GetClient(),
+		scheme: mgr.GetScheme(),
+	}
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("apitoken-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to APIToken
+	err = c.Watch(&source.Kind{
+		Type: &crdsv1alpha1.APIToken{},
+	}, &handler.EnqueueRequestForObject{})
+	if err != nil {
+		return errors.Wrap(err, "failed to start watch on apitokens")
+	}
+
+	generatedClient := kubernetes.NewForConfigOrDie(mgr.GetConfig())
+	generatedInformers := kubeinformers.NewSharedInformerFactory(generatedClient, time.Minute)
+	err = mgr.Add(manager.RunnableFunc(func(s <-chan struct{}) error {
+		generatedInformers.Start(s)
+		<-s
+		return nil
+	}))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var _ reconcile.Reconciler = &ReconcileAPIToken{}
+
+// ReconcileAPIToken reconciles a APIToken object
+type ReconcileAPIToken struct {
+	client.Client
+	scheme *runtime.Scheme
+}
+
+// Reconcile reads that state of the cluster for a APIToken object and makes changes based on the state read
+// and what is in the APIToken.Spec
+// +kubebuilder:rbac:groups=crds.kubeflare.io,resources=apitokens,verbs=get;list;watch;create;update;patch;delete
+func (r *ReconcileAPIToken) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	// This reconcile loop will be called for all APIToken objects
+	// because of the informer that we have set up
+
+	ctx := context.Background()
+	instance := &crdsv1alpha1.APIToken{}
+
+	if err := r.Get(ctx, request.NamespacedName, instance); err != nil {
+		if apiErrors.IsNotFound(err) {
+			logger.Debug("apitoken already deleted", zap.String("name", request.Name))
+			return reconcile.Result{}, nil
+		}
+
+		logger.Error(err)
+		return reconcile.Result{}, err
+	}
+
+	if err := r.handleDeletion(ctx, instance); err != nil {
+		if errors.Is(err, shared.HasDependenciesError) {
+			return reconcile.Result{
+				RequeueAfter: time.Duration(10) * time.Second,
+			}, nil
+		}
+
+		logger.Error(err)
+		return reconcile.Result{}, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (r *ReconcileAPIToken) handleDeletion(ctx context.Context, instance *crdsv1alpha1.APIToken) error {
+	containsFinalizer := controllerutil.ContainsFinalizer(instance, internal.ProtectAPITokenFinalizer)
+	isBeingDeleted := !instance.DeletionTimestamp.IsZero()
+
+	if isBeingDeleted && !containsFinalizer {
+		// object is being deleted and finalizer already executed. nothing more to do
+		return nil
+	}
+
+	if isBeingDeleted && containsFinalizer {
+		// object is being deleted check for dependencies
+		hasDeps, err := r.apiTokenHasDependents(ctx, instance)
+		if err != nil {
+			return err
+		}
+
+		if hasDeps {
+			logger.Debug("apitoken has dependencies and cannot be deleted yet", zap.String("name", instance.Name))
+			return shared.HasDependenciesError
+		}
+
+		patch := client.MergeFrom(instance.DeepCopy())
+		controllerutil.RemoveFinalizer(instance, internal.ProtectAPITokenFinalizer)
+
+		if err := client.IgnoreNotFound(r.Client.Patch(ctx, instance, patch)); err != nil {
+			return errors.Wrap(err, "failed to remove finalizer from apitoken")
+		}
+
+		logger.Debug("removed apitoken", zap.String("name", instance.Name))
+		return nil
+	}
+
+	if !isBeingDeleted && !containsFinalizer {
+		patch := client.MergeFrom(instance.DeepCopy())
+		controllerutil.AddFinalizer(instance, internal.ProtectAPITokenFinalizer)
+
+		if err := r.Client.Patch(ctx, instance, patch); err != nil {
+			return errors.Wrap(err, "could not add finalizer to apitoken")
+		}
+
+		logger.Debug("added finalizer to apitoken",
+			zap.String("name", instance.Name),
+			zap.String("finalizer", internal.ProtectAPITokenFinalizer))
+
+		if instance.Spec.ValueFrom != nil {
+			// just in case the apitoken was created after the secret
+			return r.ensureSecretHasFinalizer(ctx, instance.Spec.ValueFrom.SecretKeyRef.Name, instance.Namespace)
+		}
+	}
+
+	return nil
+}
+
+func (r *ReconcileAPIToken) ensureSecretHasFinalizer(ctx context.Context, secretName, secretNamespace string) error {
+	instance := &v1.Secret{}
+
+	err := r.Get(ctx, types.NamespacedName{
+		Namespace: secretNamespace,
+		Name:      secretName,
+	}, instance)
+
+	if err != nil {
+		if apiErrors.IsNotFound(err) {
+			logger.Debug("referenced secret not found", zap.String("name", secretName), zap.String("namespace", secretNamespace))
+			return nil
+		}
+
+		return err
+	}
+
+	if controllerutil.ContainsFinalizer(instance, internal.ProtectAPITokenFinalizer) {
+		return nil
+	}
+
+	patch := client.MergeFrom(instance.DeepCopy())
+	controllerutil.AddFinalizer(instance, internal.ProtectAPITokenFinalizer)
+
+	if err := r.Client.Patch(ctx, instance, patch); err != nil {
+		return errors.Wrap(err, "could not add finalizer to apitoken secret")
+	}
+
+	logger.Debug("added finalizer to apitoken secret",
+		zap.String("name", secretName),
+		zap.String("namespace", secretNamespace),
+		zap.String("finalizer", internal.ProtectAPITokenFinalizer))
+
+	return nil
+}
+
+func (r *ReconcileAPIToken) apiTokenHasDependents(ctx context.Context, apiToken *crdsv1alpha1.APIToken) (bool, error) {
+	crdsClient, err := shared.GetCrdClient()
+	if err != nil {
+		return false, errors.Wrap(err, "failed to create crds client")
+	}
+
+	list, err := crdsClient.Zones(apiToken.Namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return false, err
+	}
+
+	for _, zone := range list.Items {
+		if zone.Spec.APIToken == apiToken.Name {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/pkg/controller/apitoken/secret_controller.go
+++ b/pkg/controller/apitoken/secret_controller.go
@@ -1,0 +1,207 @@
+/*
+Copyright 2019 Replicated, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apitoken
+
+import (
+	"context"
+	"github.com/replicatedhq/kubeflare/pkg/internal"
+	"go.uber.org/zap"
+	v1 "k8s.io/api/core/v1"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/kubeflare/pkg/controller/shared"
+	"github.com/replicatedhq/kubeflare/pkg/logger"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubeinformers "k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+// newSecretReconciler returns a new reconcile.Reconciler
+func newSecretReconciler(mgr manager.Manager) reconcile.Reconciler {
+	return &reconcileSecret{
+		Client: mgr.GetClient(),
+		scheme: mgr.GetScheme(),
+	}
+}
+
+// addSecret adds a new Controller to mgr with r as the reconcile.Reconciler
+func addSecret(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("secret-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to Secret
+	err = c.Watch(&source.Kind{
+		Type: &v1.Secret{},
+	}, &handler.EnqueueRequestForObject{})
+	if err != nil {
+		return errors.Wrap(err, "failed to start watch on secrets")
+	}
+
+	generatedClient := kubernetes.NewForConfigOrDie(mgr.GetConfig())
+	generatedInformers := kubeinformers.NewSharedInformerFactory(generatedClient, time.Minute)
+	err = mgr.Add(manager.RunnableFunc(func(s <-chan struct{}) error {
+		generatedInformers.Start(s)
+		<-s
+		return nil
+	}))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var _ reconcile.Reconciler = &reconcileSecret{}
+
+// ReconcileSecret reconciles a Secrets related to an APIToken object
+type reconcileSecret struct {
+	client.Client
+	scheme *runtime.Scheme
+}
+
+// Reconcile reads that state of the cluster for a Secret object and makes changes based on the state read
+// if the secrets is referenced from an APIToken and protectAPIToken is true
+// +kubebuilder:rbac:groups=,resources=secrets,verbs=create,update,patch,delete
+func (r *reconcileSecret) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	ctx := context.Background()
+	instance := &v1.Secret{}
+
+	if err := r.Get(ctx, request.NamespacedName, instance); err != nil {
+		if apiErrors.IsNotFound(err) {
+			logger.Debug("secret already deleted",
+				zap.String("name", request.Name), zap.String("namespace", request.Namespace))
+
+			return reconcile.Result{}, nil
+		}
+
+		logger.Error(err)
+		return reconcile.Result{}, err
+	}
+
+	if err := r.handleDeletion(ctx, instance); err != nil {
+		if errors.Is(err, shared.HasDependenciesError) {
+			return reconcile.Result{
+				RequeueAfter: time.Duration(10) * time.Second,
+			}, nil
+		}
+
+		logger.Error(err)
+		return reconcile.Result{}, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (r *reconcileSecret) handleDeletion(ctx context.Context, instance *v1.Secret) error {
+	containsFinalizer := controllerutil.ContainsFinalizer(instance, internal.ProtectAPITokenFinalizer)
+	isBeingDeleted := !instance.DeletionTimestamp.IsZero()
+
+	if isBeingDeleted && !containsFinalizer {
+		// object is being deleted and finalizer already executed. nothing more to do
+		return nil
+	}
+
+	if isBeingDeleted && containsFinalizer {
+		// object is being deleted check for dependencies
+		hasDeps, err := secretHasDependents(ctx, instance)
+		if err != nil {
+			logger.Error(err)
+			return err
+		}
+
+		if hasDeps {
+			logger.Debug("secret has dependencies and cannot be deleted yet", zap.String("name", instance.Name))
+			return shared.HasDependenciesError
+		}
+
+		patch := client.MergeFrom(instance.DeepCopy())
+		controllerutil.RemoveFinalizer(instance, internal.ProtectAPITokenFinalizer)
+
+		if err := client.IgnoreNotFound(r.Client.Patch(ctx, instance, patch)); err != nil {
+			return errors.Wrap(err, "failed to remove finalizer from secret")
+		}
+
+		logger.Debug("removed finalizer from secret",
+			zap.String("name", instance.Name), zap.String("namespace", instance.Namespace))
+
+		return nil
+	}
+
+	if !isBeingDeleted && !containsFinalizer {
+		hasDeps, err := secretHasDependents(ctx, instance)
+		if err != nil {
+			logger.Error(err)
+			return err
+		}
+
+		if !hasDeps {
+			logger.Debug("not adding finalizer to secret, not referenced by any apitoken",
+				zap.String("name", instance.Name),
+				zap.String("namespace", instance.Namespace),
+				zap.String("finalizer", internal.ProtectAPITokenFinalizer))
+
+			return nil
+		}
+
+		patch := client.MergeFrom(instance.DeepCopy())
+		controllerutil.AddFinalizer(instance, internal.ProtectAPITokenFinalizer)
+
+		if err := r.Client.Patch(ctx, instance, patch); err != nil {
+			return errors.Wrap(err, "could not add finalizer to secret")
+		}
+
+		logger.Debug("added finalizer to secret",
+			zap.String("name", instance.Name),
+			zap.String("namespace", instance.Namespace),
+			zap.String("finalizer", internal.ProtectAPITokenFinalizer))
+	}
+
+	return nil
+}
+
+func secretHasDependents(ctx context.Context, secret *v1.Secret) (bool, error) {
+	crdsClient, err := shared.GetCrdClient()
+	if err != nil {
+		return false, err
+	}
+
+	list, err := crdsClient.APITokens(secret.Namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return false, err
+	}
+
+	for _, apiToken := range list.Items {
+		if apiToken.Spec.ValueFrom.SecretKeyRef.Name == secret.Name {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/pkg/controller/zone/settings.go
+++ b/pkg/controller/zone/settings.go
@@ -11,7 +11,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func ReconcileSettings(ctx context.Context, instance crdsv1alpha1.Zone, cf *cloudflare.API) error {
+func ReconcileSettings(ctx context.Context, instance *crdsv1alpha1.Zone, cf *cloudflare.API) error {
 	logger.Debug("reconcileSettings for zone", zap.String("zoneName", instance.Name))
 
 	if instance.Spec.Settings == nil {

--- a/pkg/controller/zone/zone_controller.go
+++ b/pkg/controller/zone/zone_controller.go
@@ -18,6 +18,12 @@ package zone
 
 import (
 	"context"
+	crdsclientv1alpha1 "github.com/replicatedhq/kubeflare/pkg/client/kubeflareclientset/typed/crds/v1alpha1"
+	"github.com/replicatedhq/kubeflare/pkg/internal"
+	"go.uber.org/zap"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"time"
 
 	"github.com/pkg/errors"
@@ -37,15 +43,16 @@ import (
 
 // Add creates a new Zone Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager) error {
-	return add(mgr, newReconciler(mgr))
+func Add(mgr manager.Manager, protectAPIToken bool) error {
+	return add(mgr, newReconciler(mgr, protectAPIToken))
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+func newReconciler(mgr manager.Manager, protectAPIToken bool) reconcile.Reconciler {
 	return &ReconcileZone{
-		Client: mgr.GetClient(),
-		scheme: mgr.GetScheme(),
+		Client:          mgr.GetClient(),
+		scheme:          mgr.GetScheme(),
+		protectAPIToken: protectAPIToken,
 	}
 }
 
@@ -84,7 +91,8 @@ var _ reconcile.Reconciler = &ReconcileZone{}
 // ReconcileZone reconciles a Zone object
 type ReconcileZone struct {
 	client.Client
-	scheme *runtime.Scheme
+	scheme          *runtime.Scheme
+	protectAPIToken bool
 }
 
 // Reconcile reads that state of the cluster for a Zone object and makes changes based on the state read
@@ -95,11 +103,35 @@ func (r *ReconcileZone) Reconcile(request reconcile.Request) (reconcile.Result, 
 	// This reconcile loop will be called for all Zone objects
 	// because of the informer that we have set up
 	ctx := context.Background()
-	instance := crdsv1alpha1.Zone{}
-	err := r.Get(ctx, request.NamespacedName, &instance)
+	instance := &crdsv1alpha1.Zone{}
+	err := r.Get(ctx, request.NamespacedName, instance)
 	if err != nil {
+		if apiErrors.IsNotFound(err) {
+			logger.Debug("zone already deleted", zap.String("name", request.Name))
+			return reconcile.Result{}, nil
+		}
+
 		logger.Error(err)
 		return reconcile.Result{}, err
+	}
+
+	if r.protectAPIToken {
+		deleted, err := r.handleDeletion(ctx, instance)
+
+		if errors.Is(err, shared.HasDependenciesError) {
+			return reconcile.Result{
+				RequeueAfter: time.Duration(10) * time.Second,
+			}, nil
+		}
+
+		if err != nil {
+			logger.Error(err)
+			return reconcile.Result{}, err
+		}
+
+		if deleted {
+			return reconcile.Result{}, nil
+		}
 	}
 
 	cf, err := shared.GetCloudflareAPI(ctx, instance.Namespace, instance.Spec.APIToken)
@@ -114,4 +146,162 @@ func (r *ReconcileZone) Reconcile(request reconcile.Request) (reconcile.Result, 
 	}
 
 	return reconcile.Result{}, nil
+}
+
+func (r *ReconcileZone) handleDeletion(ctx context.Context, instance *crdsv1alpha1.Zone) (bool, error) {
+	containsFinalizer := controllerutil.ContainsFinalizer(instance, internal.ProtectAPITokenFinalizer)
+	isBeingDeleted := !instance.DeletionTimestamp.IsZero()
+
+	if isBeingDeleted && !containsFinalizer {
+		// object is being deleted and finalizer already executed. nothing more to do
+		return true, nil
+	}
+
+	if isBeingDeleted && containsFinalizer {
+		// object is being deleted check for dependencies
+		hasDeps, err := r.zoneHasDependents(ctx, instance)
+		if err != nil {
+			logger.Error(err)
+			return false, err
+		}
+
+		if hasDeps {
+			logger.Debug("zone has dependencies and cannot be deleted yet", zap.String("name", instance.Name))
+			return false, shared.HasDependenciesError
+		}
+
+		patch := client.MergeFrom(instance.DeepCopy())
+		controllerutil.RemoveFinalizer(instance, internal.ProtectAPITokenFinalizer)
+
+		if err := client.IgnoreNotFound(r.Client.Patch(ctx, instance, patch)); err != nil {
+			return false, errors.Wrap(err, "failed to remove finalizer from zone")
+		}
+
+		logger.Debug("removed zone", zap.String("name", instance.Name))
+		return true, nil
+	}
+
+	if !isBeingDeleted && !containsFinalizer {
+		patch := client.MergeFrom(instance.DeepCopy())
+		controllerutil.AddFinalizer(instance, internal.ProtectAPITokenFinalizer)
+
+		if err := r.Client.Patch(ctx, instance, patch); err != nil {
+			return false, errors.Wrap(err, "could not add finalizer to zone")
+		}
+
+		logger.Debug("added finalizer to zone",
+			zap.String("name", instance.Name),
+			zap.String("finalizer", internal.ProtectAPITokenFinalizer))
+	}
+
+	return false, nil
+}
+
+func (r *ReconcileZone) zoneHasDependents(ctx context.Context, zone *crdsv1alpha1.Zone) (bool, error) {
+	crdsClient, err := shared.GetCrdClient()
+	if err != nil {
+		return false, err
+	}
+
+	hasDeps, err := r.zoneHasAccessAppDependents(ctx, crdsClient.AccessApplications(zone.Namespace), zone.Name)
+	if err != nil || hasDeps {
+		return hasDeps, err
+	}
+
+	hasDeps, err = r.zoneHasDNSDependents(ctx, crdsClient.DNSRecords(zone.Namespace), zone.Name)
+	if err != nil || hasDeps {
+		return hasDeps, err
+	}
+
+	hasDeps, err = r.zoneHasPageRuleDependents(ctx, crdsClient.PageRules(zone.Namespace), zone.Name)
+	if err != nil || hasDeps {
+		return hasDeps, err
+	}
+
+	hasDeps, err = r.zoneHasWAFDependents(ctx, crdsClient.WebApplicationFirewallRules(zone.Namespace), zone.Name)
+	if err != nil || hasDeps {
+		return hasDeps, err
+	}
+
+	hasDeps, err = r.zoneHasWorkerRouteDependents(ctx, crdsClient.WorkerRoutes(zone.Namespace), zone.Name)
+	if err != nil || hasDeps {
+		return hasDeps, err
+	}
+
+	return false, nil
+}
+
+func (r *ReconcileZone) zoneHasAccessAppDependents(ctx context.Context, client crdsclientv1alpha1.AccessApplicationInterface, zone string) (bool, error) {
+	list, err := client.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return false, err
+	}
+
+	for _, item := range list.Items {
+		if item.Spec.Zone == zone {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (r *ReconcileZone) zoneHasDNSDependents(ctx context.Context, client crdsclientv1alpha1.DNSRecordInterface, zone string) (bool, error) {
+	list, err := client.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return false, err
+	}
+
+	for _, item := range list.Items {
+		if item.Spec.Zone == zone {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (r *ReconcileZone) zoneHasPageRuleDependents(ctx context.Context, client crdsclientv1alpha1.PageRuleInterface, zone string) (bool, error) {
+	list, err := client.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return false, err
+	}
+
+	for _, item := range list.Items {
+		if item.Spec.Zone == zone {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (r *ReconcileZone) zoneHasWAFDependents(ctx context.Context, client crdsclientv1alpha1.WebApplicationFirewallRuleInterface, zone string) (bool, error) {
+	list, err := client.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return false, err
+	}
+
+	for _, item := range list.Items {
+		if item.Spec.Zone == zone {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (r *ReconcileZone) zoneHasWorkerRouteDependents(ctx context.Context, client crdsclientv1alpha1.WorkerRouteInterface, zone string) (bool, error) {
+	list, err := client.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return false, err
+	}
+
+	for _, item := range list.Items {
+		if item.Spec.Zone == zone {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }

--- a/pkg/internal/constants.go
+++ b/pkg/internal/constants.go
@@ -2,5 +2,6 @@ package internal
 
 const (
 	DeleteCFResourceFinalizer = "finalizers.kubeflare.io/delete-cf-resource"
+	ProtectAPITokenFinalizer  = "finalizers.kubeflare.io/protect-apitoken"
 	ImportedIDAnnotation      = "crds.kubeflare.io/imported-id"
 )


### PR DESCRIPTION
Since the credentials required to interact with Cloudflare is retrieved from the API Token resource.
We need to ensure that it is not deleted if it is still referenced.