### PR TITLE
Add arm64 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ bin
 
 # editor and IDE paraphernalia
 .idea
+.vscode
 *.swp
 *.swo
 *~

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,14 @@ bin/kubeflare:
 		-o bin/kubeflare \
 		./cmd/kubeflare
 
+.PHONY: bin/kubeflare-arm64
+bin/kubeflare-arm64:
+	env GOOS=linux GOARCH=arm64 go build \
+		${LDFLAGS} \
+		-i \
+		-o bin/kubeflare \
+		./cmd/kubeflare
+
 .PHONY: run
 run: generate fmt vet bin/kubeflare
 	./bin/kubeflare run \


### PR DESCRIPTION
Hi,

This Pull Request should fix https://github.com/replicatedhq/kubeflare/issues/30

I was not sure how the container images are ending up in **replicated/kubeflare-manager** repository, so I've just added another section to the makefile to make that binary the rest should be the same.

Would be happy to know if we can merge it or if you have any comments on how we could do this better ? I'm happy to adjust it if needed.

Personally I would think it's a good idea to build those binaries inside of the dockerfile as a separate layers for each target and then pass the dockerfile a build argument with the target.

I guess it requires the following steps:

1. make bin/kubeflare-arm64
2. docker build -t replicated/kubeflare-manager:test -f ./Dockerfile.manager .
3. docker push replicated/kubeflare-manager:test
4. try it out - and if everything is well push it to 0.2.0 TAG so it can run on both platforms

I'm going to try it on my raspberry PI most likely today, will keep you posted.

Kind regards,